### PR TITLE
Update requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -8,5 +8,5 @@ nose==1.3.0
 requests==2.2.1
 Flask-OpenID==1.2.1
 pyte==0.4.4
-boto==2.30.0
+boto==2.36.0
 fabric==1.9.0


### PR DESCRIPTION
It seems we need a boto>= 2.32.1. See stack trace below.
I got this when i clicked on the 'start cluster' button
Updating to latest boto which is 2.36.0

Starting cluster...
Traceback (most recent call last):
  File "/usr/local/bin/starcluster", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2749, in <module>
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 446, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 459, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 628, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: boto>=2.32.1
